### PR TITLE
fix: bind client as this

### DIFF
--- a/src/source-api-nodes.ts
+++ b/src/source-api-nodes.ts
@@ -21,7 +21,9 @@ export const sourceListApiNodes = async (
 ) => {
   const { createNode } = actions
 
-  const getList = includesDraft ? client.getListIncludingDraft : client.getList
+  const getList = (
+    includesDraft ? client.getListIncludingDraft : client.getList
+  ).bind(client)
 
   let total: number | undefined
   let offset = 0


### PR DESCRIPTION
ref #20 #21 

at https://github.com/hacocms/gatsby-source-hacocms/commit/9dc60e0f784582ba7647a407cf6e603106c8f766 :

```
 ERROR #11321  PLUGIN

"gatsby-source-hacocms" threw an error while running the sourceNodes lifecycle:

Cannot read properties of undefined (reading 'axiosDraft')
```